### PR TITLE
Add meeting type filter to dashboard

### DIFF
--- a/components/SalesTable.tsx
+++ b/components/SalesTable.tsx
@@ -75,6 +75,8 @@ export default function SalesTable() {
     return activities.filter(activity => {
       const matchesType = !filters.type || activity.type === filters.type;
       const matchesSalesRep = !filters.salesRep || activity.salesRep === filters.salesRep;
+      const matchesMeetingType = !filters.meetingType || 
+        (activity.type === 'meeting' && activity.details === filters.meetingType);
       const matchesSearch = !filters.searchQuery || 
         activity.clientName.toLowerCase().includes(filters.searchQuery.toLowerCase()) ||
         activity.type.toLowerCase().includes(filters.searchQuery.toLowerCase()) ||
@@ -83,7 +85,7 @@ export default function SalesTable() {
       const matchesDate = activityDate >= filters.dateRange.start && 
                          activityDate <= filters.dateRange.end;
 
-      return matchesType && matchesSalesRep && matchesSearch && matchesDate;
+      return matchesType && matchesSalesRep && matchesMeetingType && matchesSearch && matchesDate;
     });
   }, [activities, filters]);
 
@@ -637,7 +639,7 @@ export default function SalesTable() {
                   className="overflow-hidden"
                   suppressHydrationWarning
                 >
-                  <div suppressHydrationWarning className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+                  <div suppressHydrationWarning className="grid grid-cols-1 md:grid-cols-4 gap-4 mt-4">
                     <select
                       suppressHydrationWarning
                       className="bg-gray-800/50 border border-gray-700/50 rounded-xl px-4 py-2.5 text-white text-sm"
@@ -661,6 +663,19 @@ export default function SalesTable() {
                         <option key={rep} value={rep}>{rep}</option>
                       ))}
                     </select>
+                    {(!filters.type || filters.type === 'meeting') && (
+                      <select
+                        suppressHydrationWarning
+                        className="bg-gray-800/50 border border-gray-700/50 rounded-xl px-4 py-2.5 text-white text-sm"
+                        value={filters.meetingType || 'all'}
+                        onChange={(e) => setFilters({ meetingType: e.target.value === 'all' ? undefined : e.target.value })}
+                      >
+                        <option value="all">All Meeting Types</option>
+                        <option value="discovery">Discovery</option>
+                        <option value="demo">Demo</option>
+                        <option value="follow-up">Follow-up</option>
+                      </select>
+                    )}
                     <DateRangePicker
                       dateRange={{ from: filters.dateRange.start, to: filters.dateRange.end }}
                       onDateRangeChange={(range) => 

--- a/lib/hooks/useActivities.ts
+++ b/lib/hooks/useActivities.ts
@@ -19,7 +19,7 @@ const generateDummyData = async () => {
   const salesRep = profile ? `${profile.first_name} ${profile.last_name}` : 'Unknown';
   const activityTypes = ['sale', 'outbound', 'meeting', 'proposal'];
   const priorities = ['high', 'medium', 'low'];
-  const meetingTypes = ['Discovery Call', 'Product Demo', 'Follow-up'];
+  const meetingTypes = ['discovery', 'demo', 'follow-up'];
   const contactMethods = ['Phone', 'Email', 'LinkedIn'];
 
   // Generate activities for December 2024

--- a/meeting-type-filter-implementation.md
+++ b/meeting-type-filter-implementation.md
@@ -1,0 +1,86 @@
+# Meeting Type Filter Implementation
+
+## Overview
+Added a meeting type filter to the sales dashboard that allows users to filter activities by specific meeting types (Discovery, Demo, Follow-up). This enables users to easily track how many new meetings of each type they've had.
+
+## Changes Made
+
+### 1. Updated Activity Filters Hook (`src/lib/hooks/useActivityFilters.ts`)
+- Added `meetingType?: string` to the `ActivityFilters` interface
+- Updated initial state and reset function to include `meetingType: undefined`
+
+### 2. Enhanced SalesTable Component (`components/SalesTable.tsx`)
+- Updated filtering logic to include meeting type filtering:
+  ```typescript
+  const matchesMeetingType = !filters.meetingType || 
+    (activity.type === 'meeting' && activity.details === filters.meetingType);
+  ```
+- Added conditional meeting type filter dropdown in the filter panel:
+  - Only shows when activity type is 'meeting' or when no type filter is applied
+  - Options: All Meeting Types, Discovery, Demo, Follow-up
+- Changed grid layout from 3 columns to 4 columns to accommodate new filter
+
+### 3. Enhanced Dashboard (`src/pages/Dashboard.tsx`)
+- Added "Meeting Breakdown" section displaying:
+  - Discovery Calls count with trend
+  - Product Demos count with trend  
+  - Follow-up Meetings count with trend
+- Each card is clickable and navigates to the activity log with appropriate filters applied
+- Added required icon imports: `Search`, `ArrowUpRight`
+
+### 4. Standardized Meeting Types (`lib/hooks/useActivities.ts`)
+- Updated dummy data generation to use consistent meeting type values:
+  - Changed from `['Discovery Call', 'Product Demo', 'Follow-up']`
+  - To `['discovery', 'demo', 'follow-up']`
+
+## Features Added
+
+### Filter Functionality
+- **Meeting Type Filter**: Dropdown that appears when filtering by meetings or when no activity type is selected
+- **Conditional Display**: Filter only shows when relevant to avoid clutter
+- **Integration**: Works seamlessly with existing filters (date range, sales rep, search)
+
+### Dashboard Analytics
+- **Meeting Breakdown Cards**: Visual representation of meeting types with counts
+- **Trend Analysis**: Shows month-over-month change for each meeting type
+- **Click-to-Filter**: Users can click cards to drill down into specific meeting types
+- **Responsive Design**: Adapts to different screen sizes
+
+### User Experience
+- **Intuitive Filtering**: Meeting type filter only appears when filtering meetings
+- **Clear Labeling**: User-friendly labels (Discovery Calls, Product Demos, etc.)
+- **Smooth Navigation**: Clicking dashboard cards automatically applies filters and navigates to activity log
+
+## Technical Implementation
+
+### Data Structure
+Meeting types are stored in the `details` field of activities where `type === 'meeting'`:
+- `discovery` → Discovery Calls
+- `demo` → Product Demos  
+- `follow-up` → Follow-up Meetings
+
+### Filter Logic
+```typescript
+const matchesMeetingType = !filters.meetingType || 
+  (activity.type === 'meeting' && activity.details === filters.meetingType);
+```
+
+### Dashboard Calculations
+```typescript
+const count = selectedMonthActivities
+  .filter(a => a.type === 'meeting' && a.details === type)
+  .reduce((sum, a) => sum + (a.quantity || 1), 0);
+```
+
+## Benefits
+1. **Better Visibility**: Users can now see breakdown of meeting types at a glance
+2. **Improved Filtering**: Easy to filter and analyze specific types of meetings
+3. **Enhanced Reporting**: Better understanding of sales pipeline activity
+4. **User-Friendly**: Intuitive interface that only shows relevant options
+5. **Performance Tracking**: Month-over-month trends for each meeting type
+
+## Usage
+1. Navigate to the sales dashboard to see the Meeting Breakdown section
+2. Use the Activity Log's filter panel to filter by specific meeting types
+3. Click on meeting breakdown cards to automatically filter and view details
+4. Use in combination with other filters (date range, sales rep) for detailed analysis

--- a/src/lib/hooks/useActivityFilters.ts
+++ b/src/lib/hooks/useActivityFilters.ts
@@ -4,6 +4,7 @@ import { startOfMonth, endOfMonth } from 'date-fns';
 interface ActivityFilters {
   type?: string;
   salesRep?: string;
+  meetingType?: string;
   dateRange: {
     start: Date;
     end: Date;
@@ -25,7 +26,8 @@ export const useActivityFilters = create<ActivityFiltersStore>((set) => ({
       end: new Date(),
     },
     searchQuery: '',
-    salesRep: undefined
+    salesRep: undefined,
+    meetingType: undefined
   },
   setFilters: (newFilters) => 
     set((state) => ({
@@ -45,7 +47,8 @@ export const useActivityFilters = create<ActivityFiltersStore>((set) => ({
           end: new Date(),
         },
         searchQuery: '',
-        salesRep: undefined
+        salesRep: undefined,
+        meetingType: undefined
       }
     }),
 }));

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -17,6 +17,8 @@ import {
   ArrowDown,
   TrendingUp,
   TrendingDown,
+  Search,
+  ArrowUpRight,
 } from 'lucide-react';
 import SalesActivityChart from '@/components/SalesActivityChart';
 import ReactDOM from 'react-dom';
@@ -579,6 +581,84 @@ export default function Dashboard() {
           dateRange={selectedMonthRange}
           previousMonthTotal={previousMonthTotals.proposals}
         />
+      </div>
+
+      {/* Meeting Type Breakdown */}
+      <div className="bg-gray-900/50 backdrop-blur-xl rounded-xl p-6 border border-gray-800/50 mb-8">
+        <h2 className="text-xl font-semibold text-white mb-4">Meeting Breakdown</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {[
+            { 
+              type: 'discovery', 
+              label: 'Discovery Calls', 
+              color: 'blue',
+              icon: Search 
+            },
+            { 
+              type: 'demo', 
+              label: 'Product Demos', 
+              color: 'violet',
+              icon: Users 
+            },
+            { 
+              type: 'follow-up', 
+              label: 'Follow-up Meetings', 
+              color: 'emerald',
+              icon: ArrowUpRight 
+            }
+          ].map(({ type, label, color, icon: Icon }) => {
+            const count = selectedMonthActivities
+              .filter(a => a.type === 'meeting' && a.details === type)
+              .reduce((sum, a) => sum + (a.quantity || 1), 0);
+            
+            const previousCount = previousMonthToDateActivities
+              .filter(a => a.type === 'meeting' && a.details === type)
+              .reduce((sum, a) => sum + (a.quantity || 1), 0);
+            
+            const trend = previousCount > 0 ? Math.round(((count - previousCount) / previousCount) * 100) : 0;
+            
+            return (
+              <motion.div
+                key={type}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                whileHover={{ scale: 1.02 }}
+                onClick={() => {
+                  setFilters({ 
+                    type: 'meeting',
+                    meetingType: type,
+                    dateRange: selectedMonthRange 
+                  });
+                  navigate('/activity', { state: { preserveFilters: true } });
+                }}
+                className={`bg-gray-800/30 rounded-xl p-4 border border-gray-700/50 hover:bg-gray-800/50 transition-all duration-300 cursor-pointer hover:border-${color}-500/30`}
+              >
+                <div className="flex items-center gap-3 mb-3">
+                  <div className={`p-2 rounded-lg bg-${color}-500/10 border border-${color}-500/20`}>
+                    <Icon className={`w-5 h-5 text-${color}-500`} />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="font-medium text-white text-sm">{label}</h3>
+                    <p className="text-xs text-gray-400">This month</p>
+                  </div>
+                </div>
+                <div className="flex items-baseline justify-between">
+                  <span className="text-2xl font-bold text-white">{count}</span>
+                  <div className={`flex items-center gap-1 text-xs font-medium ${
+                    trend >= 0 ? `text-${color}-500` : 'text-red-500'
+                  }`}>
+                    {trend >= 0 ? (
+                      <ArrowUp className="w-3 h-3" />
+                    ) : (
+                      <ArrowDown className="w-3 h-3" />
+                    )}
+                    {trend >= 0 ? '+' : ''}{trend}%
+                  </div>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
       </div>
 
       {/* Sales Activity Chart */}


### PR DESCRIPTION
A meeting type filter was implemented for the sales dashboard.

*   The `ActivityFilters` interface in `src/lib/hooks/useActivityFilters.ts` was extended to include a `meetingType` field, enabling filtering by specific meeting types.
*   In `components/SalesTable.tsx`, the activity filtering logic was updated to include `matchesMeetingType` based on `activity.details` when `activity.type` is 'meeting'. A conditional dropdown for meeting types (Discovery, Demo, Follow-up) was added to the filter panel, appearing only when filtering by meetings or no type is selected. The filter grid layout was adjusted to accommodate this new option.
*   A "Meeting Breakdown" section was added to `src/pages/Dashboard.tsx`, displaying counts and month-over-month trends for Discovery Calls, Product Demos, and Follow-up Meetings. Each card is clickable, navigating to the activity log with pre-applied filters for the respective meeting type.
*   Dummy data generation in `lib/hooks/useActivities.ts` was standardized to use consistent lowercase meeting type values (`discovery`, `demo`, `follow-up`) for alignment with the new filtering and display logic.

These changes allow users to easily filter and view statistics for different meeting types, enhancing sales activity analysis.